### PR TITLE
Fix file links

### DIFF
--- a/docs/docs/08-References/Clients/metalctl/metalctl.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl
 title: metalctl
-sidebar_position: 1
+sidebar_position: 0
 ---
 
 ## metalctl

--- a/docs/docs/08-References/Clients/metalctl/metalctl_audit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_audit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_audit
 title: metalctl_audit
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 ## metalctl audit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_audit_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_audit_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_audit_list
 title: metalctl_audit_list
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 ## metalctl audit list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_completion.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_completion.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_completion
 title: metalctl_completion
-sidebar_position: 2
+sidebar_position: 4
 ---
 
 ## metalctl completion

--- a/docs/docs/08-References/Clients/metalctl/metalctl_completion_bash.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_completion_bash.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_completion_bash
 title: metalctl_completion_bash
-sidebar_position: 2
+sidebar_position: 5
 ---
 
 ## metalctl completion bash

--- a/docs/docs/08-References/Clients/metalctl/metalctl_completion_fish.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_completion_fish.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_completion_fish
 title: metalctl_completion_fish
-sidebar_position: 2
+sidebar_position: 6
 ---
 
 ## metalctl completion fish

--- a/docs/docs/08-References/Clients/metalctl/metalctl_completion_powershell.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_completion_powershell.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_completion_powershell
 title: metalctl_completion_powershell
-sidebar_position: 2
+sidebar_position: 7
 ---
 
 ## metalctl completion powershell

--- a/docs/docs/08-References/Clients/metalctl/metalctl_completion_zsh.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_completion_zsh.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_completion_zsh
 title: metalctl_completion_zsh
-sidebar_position: 2
+sidebar_position: 8
 ---
 
 ## metalctl completion zsh

--- a/docs/docs/08-References/Clients/metalctl/metalctl_context.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_context.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_context
 title: metalctl_context
-sidebar_position: 2
+sidebar_position: 9
 ---
 
 ## metalctl context

--- a/docs/docs/08-References/Clients/metalctl/metalctl_context_short.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_context_short.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_context_short
 title: metalctl_context_short
-sidebar_position: 2
+sidebar_position: 10
 ---
 
 ## metalctl context short

--- a/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_filesystemlayout
 title: metalctl_filesystemlayout
-sidebar_position: 2
+sidebar_position: 11
 ---
 
 ## metalctl filesystemlayout

--- a/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_apply.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_apply.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_filesystemlayout_apply
 title: metalctl_filesystemlayout_apply
-sidebar_position: 2
+sidebar_position: 12
 ---
 
 ## metalctl filesystemlayout apply

--- a/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_filesystemlayout_create
 title: metalctl_filesystemlayout_create
-sidebar_position: 2
+sidebar_position: 13
 ---
 
 ## metalctl filesystemlayout create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_filesystemlayout_delete
 title: metalctl_filesystemlayout_delete
-sidebar_position: 2
+sidebar_position: 14
 ---
 
 ## metalctl filesystemlayout delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_filesystemlayout_describe
 title: metalctl_filesystemlayout_describe
-sidebar_position: 2
+sidebar_position: 15
 ---
 
 ## metalctl filesystemlayout describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_filesystemlayout_edit
 title: metalctl_filesystemlayout_edit
-sidebar_position: 2
+sidebar_position: 16
 ---
 
 ## metalctl filesystemlayout edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_filesystemlayout_list
 title: metalctl_filesystemlayout_list
-sidebar_position: 2
+sidebar_position: 17
 ---
 
 ## metalctl filesystemlayout list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_match.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_match.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_filesystemlayout_match
 title: metalctl_filesystemlayout_match
-sidebar_position: 2
+sidebar_position: 18
 ---
 
 ## metalctl filesystemlayout match

--- a/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_try.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_try.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_filesystemlayout_try
 title: metalctl_filesystemlayout_try
-sidebar_position: 2
+sidebar_position: 19
 ---
 
 ## metalctl filesystemlayout try

--- a/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_filesystemlayout_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_filesystemlayout_update
 title: metalctl_filesystemlayout_update
-sidebar_position: 2
+sidebar_position: 20
 ---
 
 ## metalctl filesystemlayout update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_firewall.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_firewall.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_firewall
 title: metalctl_firewall
-sidebar_position: 2
+sidebar_position: 21
 ---
 
 ## metalctl firewall

--- a/docs/docs/08-References/Clients/metalctl/metalctl_firewall_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_firewall_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_firewall_create
 title: metalctl_firewall_create
-sidebar_position: 2
+sidebar_position: 22
 ---
 
 ## metalctl firewall create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_firewall_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_firewall_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_firewall_describe
 title: metalctl_firewall_describe
-sidebar_position: 2
+sidebar_position: 23
 ---
 
 ## metalctl firewall describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_firewall_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_firewall_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_firewall_list
 title: metalctl_firewall_list
-sidebar_position: 2
+sidebar_position: 24
 ---
 
 ## metalctl firewall list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_firewall_ssh.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_firewall_ssh.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_firewall_ssh
 title: metalctl_firewall_ssh
-sidebar_position: 2
+sidebar_position: 25
 ---
 
 ## metalctl firewall ssh

--- a/docs/docs/08-References/Clients/metalctl/metalctl_firmware.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_firmware.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_firmware
 title: metalctl_firmware
-sidebar_position: 2
+sidebar_position: 26
 ---
 
 ## metalctl firmware

--- a/docs/docs/08-References/Clients/metalctl/metalctl_firmware_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_firmware_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_firmware_delete
 title: metalctl_firmware_delete
-sidebar_position: 2
+sidebar_position: 27
 ---
 
 ## metalctl firmware delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_firmware_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_firmware_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_firmware_list
 title: metalctl_firmware_list
-sidebar_position: 2
+sidebar_position: 28
 ---
 
 ## metalctl firmware list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_firmware_upload.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_firmware_upload.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_firmware_upload
 title: metalctl_firmware_upload
-sidebar_position: 2
+sidebar_position: 29
 ---
 
 ## metalctl firmware upload

--- a/docs/docs/08-References/Clients/metalctl/metalctl_firmware_upload_bios.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_firmware_upload_bios.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_firmware_upload_bios
 title: metalctl_firmware_upload_bios
-sidebar_position: 2
+sidebar_position: 30
 ---
 
 ## metalctl firmware upload bios

--- a/docs/docs/08-References/Clients/metalctl/metalctl_firmware_upload_bmc.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_firmware_upload_bmc.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_firmware_upload_bmc
 title: metalctl_firmware_upload_bmc
-sidebar_position: 2
+sidebar_position: 31
 ---
 
 ## metalctl firmware upload bmc

--- a/docs/docs/08-References/Clients/metalctl/metalctl_health.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_health.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_health
 title: metalctl_health
-sidebar_position: 2
+sidebar_position: 32
 ---
 
 ## metalctl health

--- a/docs/docs/08-References/Clients/metalctl/metalctl_image.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_image.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_image
 title: metalctl_image
-sidebar_position: 2
+sidebar_position: 33
 ---
 
 ## metalctl image

--- a/docs/docs/08-References/Clients/metalctl/metalctl_image_apply.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_image_apply.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_image_apply
 title: metalctl_image_apply
-sidebar_position: 2
+sidebar_position: 34
 ---
 
 ## metalctl image apply

--- a/docs/docs/08-References/Clients/metalctl/metalctl_image_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_image_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_image_create
 title: metalctl_image_create
-sidebar_position: 2
+sidebar_position: 35
 ---
 
 ## metalctl image create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_image_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_image_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_image_delete
 title: metalctl_image_delete
-sidebar_position: 2
+sidebar_position: 36
 ---
 
 ## metalctl image delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_image_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_image_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_image_describe
 title: metalctl_image_describe
-sidebar_position: 2
+sidebar_position: 37
 ---
 
 ## metalctl image describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_image_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_image_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_image_edit
 title: metalctl_image_edit
-sidebar_position: 2
+sidebar_position: 38
 ---
 
 ## metalctl image edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_image_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_image_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_image_list
 title: metalctl_image_list
-sidebar_position: 2
+sidebar_position: 39
 ---
 
 ## metalctl image list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_image_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_image_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_image_update
 title: metalctl_image_update
-sidebar_position: 2
+sidebar_position: 40
 ---
 
 ## metalctl image update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_login.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_login.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_login
 title: metalctl_login
-sidebar_position: 2
+sidebar_position: 41
 ---
 
 ## metalctl login

--- a/docs/docs/08-References/Clients/metalctl/metalctl_logout.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_logout.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_logout
 title: metalctl_logout
-sidebar_position: 2
+sidebar_position: 42
 ---
 
 ## metalctl logout

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine
 title: metalctl_machine
-sidebar_position: 2
+sidebar_position: 43
 ---
 
 ## metalctl machine

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_apply.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_apply.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_apply
 title: metalctl_machine_apply
-sidebar_position: 2
+sidebar_position: 44
 ---
 
 ## metalctl machine apply

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_console.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_console.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_console
 title: metalctl_machine_console
-sidebar_position: 2
+sidebar_position: 45
 ---
 
 ## metalctl machine console

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_consolepassword.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_consolepassword.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_consolepassword
 title: metalctl_machine_consolepassword
-sidebar_position: 2
+sidebar_position: 46
 ---
 
 ## metalctl machine consolepassword

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_create
 title: metalctl_machine_create
-sidebar_position: 2
+sidebar_position: 47
 ---
 
 ## metalctl machine create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_delete
 title: metalctl_machine_delete
-sidebar_position: 2
+sidebar_position: 48
 ---
 
 ## metalctl machine delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_describe
 title: metalctl_machine_describe
-sidebar_position: 2
+sidebar_position: 49
 ---
 
 ## metalctl machine describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_edit
 title: metalctl_machine_edit
-sidebar_position: 2
+sidebar_position: 50
 ---
 
 ## metalctl machine edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_identify.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_identify.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_identify
 title: metalctl_machine_identify
-sidebar_position: 2
+sidebar_position: 51
 ---
 
 ## metalctl machine identify

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_identify_off.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_identify_off.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_identify_off
 title: metalctl_machine_identify_off
-sidebar_position: 2
+sidebar_position: 52
 ---
 
 ## metalctl machine identify off

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_identify_on.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_identify_on.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_identify_on
 title: metalctl_machine_identify_on
-sidebar_position: 2
+sidebar_position: 53
 ---
 
 ## metalctl machine identify on

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_ipmi.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_ipmi.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_ipmi
 title: metalctl_machine_ipmi
-sidebar_position: 2
+sidebar_position: 54
 ---
 
 ## metalctl machine ipmi

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_ipmi_events.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_ipmi_events.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_ipmi_events
 title: metalctl_machine_ipmi_events
-sidebar_position: 2
+sidebar_position: 55
 ---
 
 ## metalctl machine ipmi events

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_issues.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_issues.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_issues
 title: metalctl_machine_issues
-sidebar_position: 2
+sidebar_position: 56
 ---
 
 ## metalctl machine issues

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_issues_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_issues_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_issues_list
 title: metalctl_machine_issues_list
-sidebar_position: 2
+sidebar_position: 57
 ---
 
 ## metalctl machine issues list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_list
 title: metalctl_machine_list
-sidebar_position: 2
+sidebar_position: 58
 ---
 
 ## metalctl machine list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_lock.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_lock.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_lock
 title: metalctl_machine_lock
-sidebar_position: 2
+sidebar_position: 59
 ---
 
 ## metalctl machine lock

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_logs.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_logs.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_logs
 title: metalctl_machine_logs
-sidebar_position: 2
+sidebar_position: 60
 ---
 
 ## metalctl machine logs

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_power.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_power.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_power
 title: metalctl_machine_power
-sidebar_position: 2
+sidebar_position: 61
 ---
 
 ## metalctl machine power

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_bios.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_bios.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_power_bios
 title: metalctl_machine_power_bios
-sidebar_position: 2
+sidebar_position: 62
 ---
 
 ## metalctl machine power bios

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_cycle.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_cycle.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_power_cycle
 title: metalctl_machine_power_cycle
-sidebar_position: 2
+sidebar_position: 63
 ---
 
 ## metalctl machine power cycle

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_disk.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_disk.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_power_disk
 title: metalctl_machine_power_disk
-sidebar_position: 2
+sidebar_position: 64
 ---
 
 ## metalctl machine power disk

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_off.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_off.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_power_off
 title: metalctl_machine_power_off
-sidebar_position: 2
+sidebar_position: 65
 ---
 
 ## metalctl machine power off

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_on.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_on.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_power_on
 title: metalctl_machine_power_on
-sidebar_position: 2
+sidebar_position: 66
 ---
 
 ## metalctl machine power on

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_pxe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_pxe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_power_pxe
 title: metalctl_machine_power_pxe
-sidebar_position: 2
+sidebar_position: 67
 ---
 
 ## metalctl machine power pxe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_reset.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_power_reset.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_power_reset
 title: metalctl_machine_power_reset
-sidebar_position: 2
+sidebar_position: 68
 ---
 
 ## metalctl machine power reset

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_reinstall.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_reinstall.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_reinstall
 title: metalctl_machine_reinstall
-sidebar_position: 2
+sidebar_position: 69
 ---
 
 ## metalctl machine reinstall

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_reserve.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_reserve.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_reserve
 title: metalctl_machine_reserve
-sidebar_position: 2
+sidebar_position: 70
 ---
 
 ## metalctl machine reserve

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_update-firmware.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_update-firmware.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_update-firmware
 title: metalctl_machine_update-firmware
-sidebar_position: 2
+sidebar_position: 71
 ---
 
 ## metalctl machine update-firmware

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_update-firmware_bios.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_update-firmware_bios.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_update-firmware_bios
 title: metalctl_machine_update-firmware_bios
-sidebar_position: 2
+sidebar_position: 72
 ---
 
 ## metalctl machine update-firmware bios

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_update-firmware_bmc.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_update-firmware_bmc.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_update-firmware_bmc
 title: metalctl_machine_update-firmware_bmc
-sidebar_position: 2
+sidebar_position: 73
 ---
 
 ## metalctl machine update-firmware bmc

--- a/docs/docs/08-References/Clients/metalctl/metalctl_machine_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_machine_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_machine_update
 title: metalctl_machine_update
-sidebar_position: 2
+sidebar_position: 74
 ---
 
 ## metalctl machine update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_markdown.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_markdown.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_markdown
 title: metalctl_markdown
-sidebar_position: 2
+sidebar_position: 75
 ---
 
 ## metalctl markdown

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network
 title: metalctl_network
-sidebar_position: 2
+sidebar_position: 76
 ---
 
 ## metalctl network

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_allocate.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_allocate.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_allocate
 title: metalctl_network_allocate
-sidebar_position: 2
+sidebar_position: 77
 ---
 
 ## metalctl network allocate

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_apply.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_apply.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_apply
 title: metalctl_network_apply
-sidebar_position: 2
+sidebar_position: 78
 ---
 
 ## metalctl network apply

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_create
 title: metalctl_network_create
-sidebar_position: 2
+sidebar_position: 79
 ---
 
 ## metalctl network create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_delete
 title: metalctl_network_delete
-sidebar_position: 2
+sidebar_position: 80
 ---
 
 ## metalctl network delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_describe
 title: metalctl_network_describe
-sidebar_position: 2
+sidebar_position: 81
 ---
 
 ## metalctl network describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_edit
 title: metalctl_network_edit
-sidebar_position: 2
+sidebar_position: 82
 ---
 
 ## metalctl network edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_free.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_free.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_free
 title: metalctl_network_free
-sidebar_position: 2
+sidebar_position: 83
 ---
 
 ## metalctl network free

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_ip.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_ip.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_ip
 title: metalctl_network_ip
-sidebar_position: 2
+sidebar_position: 84
 ---
 
 ## metalctl network ip

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_apply.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_apply.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_ip_apply
 title: metalctl_network_ip_apply
-sidebar_position: 2
+sidebar_position: 85
 ---
 
 ## metalctl network ip apply

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_ip_create
 title: metalctl_network_ip_create
-sidebar_position: 2
+sidebar_position: 86
 ---
 
 ## metalctl network ip create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_ip_delete
 title: metalctl_network_ip_delete
-sidebar_position: 2
+sidebar_position: 87
 ---
 
 ## metalctl network ip delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_ip_describe
 title: metalctl_network_ip_describe
-sidebar_position: 2
+sidebar_position: 88
 ---
 
 ## metalctl network ip describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_ip_edit
 title: metalctl_network_ip_edit
-sidebar_position: 2
+sidebar_position: 89
 ---
 
 ## metalctl network ip edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_issues.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_issues.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_ip_issues
 title: metalctl_network_ip_issues
-sidebar_position: 2
+sidebar_position: 90
 ---
 
 ## metalctl network ip issues

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_ip_list
 title: metalctl_network_ip_list
-sidebar_position: 2
+sidebar_position: 91
 ---
 
 ## metalctl network ip list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_ip_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_ip_update
 title: metalctl_network_ip_update
-sidebar_position: 2
+sidebar_position: 92
 ---
 
 ## metalctl network ip update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_list
 title: metalctl_network_list
-sidebar_position: 2
+sidebar_position: 93
 ---
 
 ## metalctl network list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_network_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_network_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_network_update
 title: metalctl_network_update
-sidebar_position: 2
+sidebar_position: 94
 ---
 
 ## metalctl network update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_partition.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_partition.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_partition
 title: metalctl_partition
-sidebar_position: 2
+sidebar_position: 95
 ---
 
 ## metalctl partition

--- a/docs/docs/08-References/Clients/metalctl/metalctl_partition_apply.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_partition_apply.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_partition_apply
 title: metalctl_partition_apply
-sidebar_position: 2
+sidebar_position: 96
 ---
 
 ## metalctl partition apply

--- a/docs/docs/08-References/Clients/metalctl/metalctl_partition_capacity.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_partition_capacity.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_partition_capacity
 title: metalctl_partition_capacity
-sidebar_position: 2
+sidebar_position: 97
 ---
 
 ## metalctl partition capacity

--- a/docs/docs/08-References/Clients/metalctl/metalctl_partition_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_partition_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_partition_create
 title: metalctl_partition_create
-sidebar_position: 2
+sidebar_position: 98
 ---
 
 ## metalctl partition create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_partition_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_partition_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_partition_delete
 title: metalctl_partition_delete
-sidebar_position: 2
+sidebar_position: 99
 ---
 
 ## metalctl partition delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_partition_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_partition_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_partition_describe
 title: metalctl_partition_describe
-sidebar_position: 2
+sidebar_position: 100
 ---
 
 ## metalctl partition describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_partition_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_partition_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_partition_edit
 title: metalctl_partition_edit
-sidebar_position: 2
+sidebar_position: 101
 ---
 
 ## metalctl partition edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_partition_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_partition_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_partition_list
 title: metalctl_partition_list
-sidebar_position: 2
+sidebar_position: 102
 ---
 
 ## metalctl partition list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_partition_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_partition_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_partition_update
 title: metalctl_partition_update
-sidebar_position: 2
+sidebar_position: 103
 ---
 
 ## metalctl partition update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_project.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_project.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_project
 title: metalctl_project
-sidebar_position: 2
+sidebar_position: 104
 ---
 
 ## metalctl project

--- a/docs/docs/08-References/Clients/metalctl/metalctl_project_apply.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_project_apply.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_project_apply
 title: metalctl_project_apply
-sidebar_position: 2
+sidebar_position: 105
 ---
 
 ## metalctl project apply

--- a/docs/docs/08-References/Clients/metalctl/metalctl_project_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_project_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_project_create
 title: metalctl_project_create
-sidebar_position: 2
+sidebar_position: 106
 ---
 
 ## metalctl project create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_project_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_project_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_project_delete
 title: metalctl_project_delete
-sidebar_position: 2
+sidebar_position: 107
 ---
 
 ## metalctl project delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_project_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_project_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_project_describe
 title: metalctl_project_describe
-sidebar_position: 2
+sidebar_position: 108
 ---
 
 ## metalctl project describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_project_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_project_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_project_edit
 title: metalctl_project_edit
-sidebar_position: 2
+sidebar_position: 109
 ---
 
 ## metalctl project edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_project_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_project_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_project_list
 title: metalctl_project_list
-sidebar_position: 2
+sidebar_position: 110
 ---
 
 ## metalctl project list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_project_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_project_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_project_update
 title: metalctl_project_update
-sidebar_position: 2
+sidebar_position: 111
 ---
 
 ## metalctl project update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size
 title: metalctl_size
-sidebar_position: 2
+sidebar_position: 112
 ---
 
 ## metalctl size

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_apply.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_apply.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_apply
 title: metalctl_size_apply
-sidebar_position: 2
+sidebar_position: 113
 ---
 
 ## metalctl size apply

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_create
 title: metalctl_size_create
-sidebar_position: 2
+sidebar_position: 114
 ---
 
 ## metalctl size create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_delete
 title: metalctl_size_delete
-sidebar_position: 2
+sidebar_position: 115
 ---
 
 ## metalctl size delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_describe
 title: metalctl_size_describe
-sidebar_position: 2
+sidebar_position: 116
 ---
 
 ## metalctl size describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_edit
 title: metalctl_size_edit
-sidebar_position: 2
+sidebar_position: 117
 ---
 
 ## metalctl size edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_imageconstraint
 title: metalctl_size_imageconstraint
-sidebar_position: 2
+sidebar_position: 118
 ---
 
 ## metalctl size imageconstraint

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_apply.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_apply.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_imageconstraint_apply
 title: metalctl_size_imageconstraint_apply
-sidebar_position: 2
+sidebar_position: 119
 ---
 
 ## metalctl size imageconstraint apply

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_imageconstraint_create
 title: metalctl_size_imageconstraint_create
-sidebar_position: 2
+sidebar_position: 120
 ---
 
 ## metalctl size imageconstraint create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_imageconstraint_delete
 title: metalctl_size_imageconstraint_delete
-sidebar_position: 2
+sidebar_position: 121
 ---
 
 ## metalctl size imageconstraint delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_imageconstraint_describe
 title: metalctl_size_imageconstraint_describe
-sidebar_position: 2
+sidebar_position: 122
 ---
 
 ## metalctl size imageconstraint describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_imageconstraint_edit
 title: metalctl_size_imageconstraint_edit
-sidebar_position: 2
+sidebar_position: 123
 ---
 
 ## metalctl size imageconstraint edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_imageconstraint_list
 title: metalctl_size_imageconstraint_list
-sidebar_position: 2
+sidebar_position: 124
 ---
 
 ## metalctl size imageconstraint list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_try.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_try.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_imageconstraint_try
 title: metalctl_size_imageconstraint_try
-sidebar_position: 2
+sidebar_position: 125
 ---
 
 ## metalctl size imageconstraint try

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_imageconstraint_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_imageconstraint_update
 title: metalctl_size_imageconstraint_update
-sidebar_position: 2
+sidebar_position: 126
 ---
 
 ## metalctl size imageconstraint update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_list
 title: metalctl_size_list
-sidebar_position: 2
+sidebar_position: 127
 ---
 
 ## metalctl size list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_reservation
 title: metalctl_size_reservation
-sidebar_position: 2
+sidebar_position: 128
 ---
 
 ## metalctl size reservation

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_apply.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_apply.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_reservation_apply
 title: metalctl_size_reservation_apply
-sidebar_position: 2
+sidebar_position: 129
 ---
 
 ## metalctl size reservation apply

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_reservation_create
 title: metalctl_size_reservation_create
-sidebar_position: 2
+sidebar_position: 130
 ---
 
 ## metalctl size reservation create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_reservation_delete
 title: metalctl_size_reservation_delete
-sidebar_position: 2
+sidebar_position: 131
 ---
 
 ## metalctl size reservation delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_reservation_describe
 title: metalctl_size_reservation_describe
-sidebar_position: 2
+sidebar_position: 132
 ---
 
 ## metalctl size reservation describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_reservation_edit
 title: metalctl_size_reservation_edit
-sidebar_position: 2
+sidebar_position: 133
 ---
 
 ## metalctl size reservation edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_reservation_list
 title: metalctl_size_reservation_list
-sidebar_position: 2
+sidebar_position: 134
 ---
 
 ## metalctl size reservation list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_reservation_update
 title: metalctl_size_reservation_update
-sidebar_position: 2
+sidebar_position: 135
 ---
 
 ## metalctl size reservation update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_usage.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_reservation_usage.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_reservation_usage
 title: metalctl_size_reservation_usage
-sidebar_position: 2
+sidebar_position: 136
 ---
 
 ## metalctl size reservation usage

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_suggest.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_suggest.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_suggest
 title: metalctl_size_suggest
-sidebar_position: 2
+sidebar_position: 137
 ---
 
 ## metalctl size suggest

--- a/docs/docs/08-References/Clients/metalctl/metalctl_size_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_size_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_size_update
 title: metalctl_size_update
-sidebar_position: 2
+sidebar_position: 138
 ---
 
 ## metalctl size update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch
 title: metalctl_switch
-sidebar_position: 2
+sidebar_position: 139
 ---
 
 ## metalctl switch

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_connected-machines.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_connected-machines.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_connected-machines
 title: metalctl_switch_connected-machines
-sidebar_position: 2
+sidebar_position: 140
 ---
 
 ## metalctl switch connected-machines

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_console.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_console.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_console
 title: metalctl_switch_console
-sidebar_position: 2
+sidebar_position: 141
 ---
 
 ## metalctl switch console

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_delete
 title: metalctl_switch_delete
-sidebar_position: 2
+sidebar_position: 142
 ---
 
 ## metalctl switch delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_describe
 title: metalctl_switch_describe
-sidebar_position: 2
+sidebar_position: 143
 ---
 
 ## metalctl switch describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_detail.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_detail.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_detail
 title: metalctl_switch_detail
-sidebar_position: 2
+sidebar_position: 144
 ---
 
 ## metalctl switch detail

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_edit
 title: metalctl_switch_edit
-sidebar_position: 2
+sidebar_position: 145
 ---
 
 ## metalctl switch edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_list
 title: metalctl_switch_list
-sidebar_position: 2
+sidebar_position: 146
 ---
 
 ## metalctl switch list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_migrate.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_migrate.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_migrate
 title: metalctl_switch_migrate
-sidebar_position: 2
+sidebar_position: 147
 ---
 
 ## metalctl switch migrate

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_port.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_port.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_port
 title: metalctl_switch_port
-sidebar_position: 2
+sidebar_position: 148
 ---
 
 ## metalctl switch port

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_port_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_port_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_port_describe
 title: metalctl_switch_port_describe
-sidebar_position: 2
+sidebar_position: 149
 ---
 
 ## metalctl switch port describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_port_down.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_port_down.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_port_down
 title: metalctl_switch_port_down
-sidebar_position: 2
+sidebar_position: 150
 ---
 
 ## metalctl switch port down

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_port_up.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_port_up.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_port_up
 title: metalctl_switch_port_up
-sidebar_position: 2
+sidebar_position: 151
 ---
 
 ## metalctl switch port up

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_replace.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_replace.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_replace
 title: metalctl_switch_replace
-sidebar_position: 2
+sidebar_position: 152
 ---
 
 ## metalctl switch replace

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_ssh.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_ssh.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_ssh
 title: metalctl_switch_ssh
-sidebar_position: 2
+sidebar_position: 153
 ---
 
 ## metalctl switch ssh

--- a/docs/docs/08-References/Clients/metalctl/metalctl_switch_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_switch_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_switch_update
 title: metalctl_switch_update
-sidebar_position: 2
+sidebar_position: 154
 ---
 
 ## metalctl switch update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_tenant.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_tenant.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_tenant
 title: metalctl_tenant
-sidebar_position: 2
+sidebar_position: 155
 ---
 
 ## metalctl tenant

--- a/docs/docs/08-References/Clients/metalctl/metalctl_tenant_apply.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_tenant_apply.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_tenant_apply
 title: metalctl_tenant_apply
-sidebar_position: 2
+sidebar_position: 156
 ---
 
 ## metalctl tenant apply

--- a/docs/docs/08-References/Clients/metalctl/metalctl_tenant_create.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_tenant_create.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_tenant_create
 title: metalctl_tenant_create
-sidebar_position: 2
+sidebar_position: 157
 ---
 
 ## metalctl tenant create

--- a/docs/docs/08-References/Clients/metalctl/metalctl_tenant_delete.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_tenant_delete.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_tenant_delete
 title: metalctl_tenant_delete
-sidebar_position: 2
+sidebar_position: 158
 ---
 
 ## metalctl tenant delete

--- a/docs/docs/08-References/Clients/metalctl/metalctl_tenant_describe.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_tenant_describe.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_tenant_describe
 title: metalctl_tenant_describe
-sidebar_position: 2
+sidebar_position: 159
 ---
 
 ## metalctl tenant describe

--- a/docs/docs/08-References/Clients/metalctl/metalctl_tenant_edit.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_tenant_edit.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_tenant_edit
 title: metalctl_tenant_edit
-sidebar_position: 2
+sidebar_position: 160
 ---
 
 ## metalctl tenant edit

--- a/docs/docs/08-References/Clients/metalctl/metalctl_tenant_list.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_tenant_list.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_tenant_list
 title: metalctl_tenant_list
-sidebar_position: 2
+sidebar_position: 161
 ---
 
 ## metalctl tenant list

--- a/docs/docs/08-References/Clients/metalctl/metalctl_tenant_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_tenant_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_tenant_update
 title: metalctl_tenant_update
-sidebar_position: 2
+sidebar_position: 162
 ---
 
 ## metalctl tenant update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_update.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_update.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_update
 title: metalctl_update
-sidebar_position: 2
+sidebar_position: 163
 ---
 
 ## metalctl update

--- a/docs/docs/08-References/Clients/metalctl/metalctl_update_check.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_update_check.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_update_check
 title: metalctl_update_check
-sidebar_position: 2
+sidebar_position: 164
 ---
 
 ## metalctl update check

--- a/docs/docs/08-References/Clients/metalctl/metalctl_update_do.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_update_do.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_update_do
 title: metalctl_update_do
-sidebar_position: 2
+sidebar_position: 165
 ---
 
 ## metalctl update do

--- a/docs/docs/08-References/Clients/metalctl/metalctl_version.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_version.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_version
 title: metalctl_version
-sidebar_position: 2
+sidebar_position: 166
 ---
 
 ## metalctl version

--- a/docs/docs/08-References/Clients/metalctl/metalctl_vpn.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_vpn.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_vpn
 title: metalctl_vpn
-sidebar_position: 2
+sidebar_position: 167
 ---
 
 ## metalctl vpn

--- a/docs/docs/08-References/Clients/metalctl/metalctl_vpn_key.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_vpn_key.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_vpn_key
 title: metalctl_vpn_key
-sidebar_position: 2
+sidebar_position: 168
 ---
 
 ## metalctl vpn key

--- a/docs/docs/08-References/Clients/metalctl/metalctl_whoami.md
+++ b/docs/docs/08-References/Clients/metalctl/metalctl_whoami.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/metalctl_whoami
 title: metalctl_whoami
-sidebar_position: 2
+sidebar_position: 169
 ---
 
 ## metalctl whoami

--- a/docs/docs/08-References/Control Plane/backup-restore-sidecar/backup-restore-sidecar.md
+++ b/docs/docs/08-References/Control Plane/backup-restore-sidecar/backup-restore-sidecar.md
@@ -14,14 +14,15 @@ Probably, it does not make sense to use this project with large databases. Howev
 
 ## Supported Databases
 
-| Database    | Image        | Status | Upgrade Support |
-| ----------- | ------------ | :----: | :-------------: |
-| postgres    | >= 12-alpine |  beta  |       ✅        |
-| rethinkdb   | >= 2.4.0     |  beta  |       ❌        |
-| ETCD        | >= 3.5       | alpha  |       ❌        |
-| redis       | >= 6.0       | alpha  |       ❌        |
-| keydb       | >= 6.0       | alpha  |       ❌        |
-| localfs     |              | alpha  |       ❌        |
+| Database  | Image        | Status | Upgrade Support |
+|-----------|--------------|:------:|:---------------:|
+| postgres  | >= 12-alpine |  beta  |        ✅        |
+| rethinkdb | >= 2.4.0     |  beta  |        ❌        |
+| ETCD      | >= 3.5       | alpha  |        ❌        |
+| redis     | >= 6.0       | alpha  |        ❌        |
+| keydb     | >= 6.0       | alpha  |        ❌        |
+| valkey    | >= 8.1       | alpha  |        ❌        |
+| localfs   |              | alpha  |        ❌        |
 
 Postgres also supports updates when using the TimescaleDB extension. Please consider the integration test for supported upgrade paths.
 

--- a/docs/docs/08-References/Control Plane/backup-restore-sidecar/manual_restore.md
+++ b/docs/docs/08-References/Control Plane/backup-restore-sidecar/manual_restore.md
@@ -1,7 +1,7 @@
 ---
 slug: /references/manual_restore
 title: manual_restore
-sidebar_position: 1
+sidebar_position: 0
 ---
 
 # Manual Restoration
@@ -11,8 +11,8 @@ The advantage of the backup-restore-sidecar is that it automatically restores th
 1. Take a copy of your existing stateful set by running `kubectl get sts -o yaml <your-database-sts>`
 2. Now, get into a clean state, i.e. delete the existing stateful set and the pvc of your database
 3. Deploy the exact stateful set you had but only with the backup-restore-sidecar container and tail some file such that container does not die. This is your "helper" stateful set, which you can use for manual administration. 
-   - For postgres check the example [here](../deploy/postgres_manual_restore.yaml)
-   - For rethinkdb check the example [here](../deploy/rethinkdb_manual_restore.yaml)
+   - For postgres check the example [here](https://github.com/metal-stack/backup-restore-sidecar/blob/master/deploy/postgres_manual_restore.yaml)
+   - For rethinkdb check the example [here](https://github.com/metal-stack/backup-restore-sidecar/blob/master/deploy/rethinkdb_manual_restore.yaml)
 4. Enter the container in your "helper" pod by running `kubectl exec -it <your-database-helper-pod>-0 -c backup-restore-sidecar -- bash`
 5. Inside the container, you can view the existing backup versions using `backup-restore-sidecar restore ls`
 6. Choose the version to restore by running `backup-restore-sidecar restore <version>`

--- a/docs/docs/08-References/Kubernetes/cluster-api-provider-metal-stack/cluster-api-provider-metal-stack.md
+++ b/docs/docs/08-References/Kubernetes/cluster-api-provider-metal-stack/cluster-api-provider-metal-stack.md
@@ -15,8 +15,8 @@ The Cluster API provider for metal-stack (CAPMS) implements the declarative mana
 
 Currently, we provide the following custom resources:
 
-- [`MetalStackCluster`](./api/v1alpha1/metalstackcluster_types.go) can be used as [infrastructure cluster](https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-cluster) and ensures that there is a control plane IP for the cluster.
-- [`MetalStackMachine`](./api/v1alpha1/metalstackmachine_types.go) bridges between [infrastructure machines](https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-machine) and metal-stack machines.
+- [`MetalStackCluster`](https://github.com/metal-stack/cluster-api-provider-metal-stack/blob/main/./api/v1alpha1/metalstackcluster_types.go) can be used as [infrastructure cluster](https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-cluster) and ensures that there is a control plane IP for the cluster.
+- [`MetalStackMachine`](https://github.com/metal-stack/cluster-api-provider-metal-stack/blob/main/./api/v1alpha1/metalstackmachine_types.go) bridges between [infrastructure machines](https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-machine) and metal-stack machines.
 
 > [!note]
 > Currently our infrastructure provider is only tested against the [Cluster API bootstrap provider Kubeadm (CABPK)](https://cluster-api.sigs.k8s.io/tasks/bootstrap/kubeadm-bootstrap/index.html?highlight=kubeadm#cluster-api-bootstrap-provider-kubeadm).

--- a/scripts/components.json
+++ b/scripts/components.json
@@ -18,10 +18,10 @@
     "components": [
       {
         "name": "backup-restore-sidecar",
-        "releasePath": "docker-images.metal-stack.generic.backup-restore-sidecar.tag",
+        "releasePath": "",
         "repo": "metal-stack/backup-restore-sidecar",
-        "branch": "main",
-        "tag": "v0.12.1",
+        "branch": "master",
+        "tag": "",
         "position": 1,
         "withDocs": true
       },


### PR DESCRIPTION
Closes #36

- The fetch-readmes.js script replaces relative links to non-md and non-image files with an absolute link to the github-webpage
- Page numbering for docs-pages