### PR TITLE
Remove julia parts

### DIFF
--- a/blog/2021/02-ipv6-part1/index.md
+++ b/blog/2021/02-ipv6-part1/index.md
@@ -175,7 +175,7 @@ As it turns out we got even more. Because we switched all network object manipul
 
 Shown below are the benchmark results before and after using `inet.af/netaddr`
 
-```sh
+```bash
 name                    old time/op    new time/op    delta
 NewPrefixMemory-4         3.15µs ± 1%    2.34µs ± 7%   -25.56%  (p=0.016 n=4+5)
 NewPrefixPostgres-4       10.3ms ± 6%    10.1ms ±12%      ~     (p=0.686 n=4+4)

--- a/docs/contributing/01-Proposals/MEP10/README.md
+++ b/docs/contributing/01-Proposals/MEP10/README.md
@@ -31,7 +31,7 @@ files created by `metal-core`. But by using the split mode, the integrated confi
 we have to write our BGP configuration to the daemon-specific files `bgp.conf`, `staticd.conf`, and `zebra.conf` instead
 to `frr.conf`.
 
-```shell
+```bash
 elif [ "$CONFIG_TYPE" == "split" ]; then
     echo "no service integrated-vtysh-config" > /etc/frr/vtysh.conf
     rm -f /etc/frr/frr.conf

--- a/docs/docs/04-For Operators/03-deployment-guide.md
+++ b/docs/docs/04-For Operators/03-deployment-guide.md
@@ -75,18 +75,11 @@ At the end of this section we are gonna end up with the following files and fold
 
 You can already define the `inventories/group_vars/all/images.yaml` file. It contains the metal-stack version you are gonna deploy:
 
-````@eval
-using Docs
 
-t = """
 ```yaml
 ---
-metal_stack_release_version: %s
+metal_stack_release_version: <metal-stack-release-version>
 ```
-"""
-
-markdownTemplate(t, releaseVersion())
-````
 
 ### Releases and Ansible Role Dependencies
 
@@ -450,30 +443,21 @@ For the actual communication between the metal-api and the user clients (REST AP
 
 Finally, it should be possible to run the deployment through a Docker container. Make sure to have the [Kubeconfig file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) of your cluster and set the path in the following command accordingly:
 
-````@eval
-using Docs
-
-base_image = releaseVector()["docker-images"]["metal-stack"]["generic"]["deployment-base"]["tag"]
-
-t = raw"""
 ```bash
 export KUBECONFIG=<path-to-your-cluster-kubeconfig>
+export METAL_VERSION=<metal-stack-release-version>
 docker run --rm -it \
   -v $(pwd):/workdir \
   --workdir /workdir \
   -e KUBECONFIG="${KUBECONFIG}" \
   -e K8S_AUTH_KUBECONFIG="${KUBECONFIG}" \
   -e ANSIBLE_INVENTORY=inventories/control-plane.yaml \
-  ghcr.io/metal-stack/metal-deployment-base:%s \
+  ghcr.io/metal-stack/metal-deployment-base:${METAL_VERSION} \
   /bin/bash -ce \
     "ansible-playbook obtain_role_requirements.yaml
      ansible-galaxy install -r requirements.yaml
      ansible-playbook deploy_metal_control_plane.yaml"
 ```
-"""
-
-markdownTemplate(t, base_image)
-````
 
 :::tip
 If you are having issues regarding the deployment take a look at the [troubleshoot document](./06-troubleshoot.md). Please give feedback such that we can make the deployment of the metal-stack easier for you and for others!

--- a/docs/docs/05-Concepts/01-architecture.md
+++ b/docs/docs/05-Concepts/01-architecture.md
@@ -119,7 +119,7 @@ The following sequence diagram illustrates some of the main principles of the ma
 
 Here is a video showing a screen capture of a machine's serial console while running the metal-hammer in "wait mode". Then, a user allocates the machine and the metal-hammer installs the target operating system and the machine boots into the new operating system kernel via the kexec system call.
 
-```@raw html
+```html
 <div class="video-container">
 <iframe src="https://www.youtube-nocookie.com/embed/3oEhInk6BaU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -230,6 +230,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
+      additionalLanguages: ['bash']
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/versioned_docs/version-v0.21.8/contributing/01-Proposals/MEP10/README.md
+++ b/versioned_docs/version-v0.21.8/contributing/01-Proposals/MEP10/README.md
@@ -31,7 +31,7 @@ files created by `metal-core`. But by using the split mode, the integrated confi
 we have to write our BGP configuration to the daemon-specific files `bgp.conf`, `staticd.conf`, and `zebra.conf` instead
 to `frr.conf`.
 
-```shell
+```bash
 elif [ "$CONFIG_TYPE" == "split" ]; then
     echo "no service integrated-vtysh-config" > /etc/frr/vtysh.conf
     rm -f /etc/frr/frr.conf

--- a/versioned_docs/version-v0.21.8/docs/04-For Operators/03-deployment-guide.md
+++ b/versioned_docs/version-v0.21.8/docs/04-For Operators/03-deployment-guide.md
@@ -75,18 +75,10 @@ At the end of this section we are gonna end up with the following files and fold
 
 You can already define the `inventories/group_vars/all/images.yaml` file. It contains the metal-stack version you are gonna deploy:
 
-````@eval
-using Docs
-
-t = """
 ```yaml
 ---
-metal_stack_release_version: %s
+metal_stack_release_version: <metal-stack-release-version>
 ```
-"""
-
-markdownTemplate(t, releaseVersion())
-````
 
 ### Releases and Ansible Role Dependencies
 
@@ -450,30 +442,21 @@ For the actual communication between the metal-api and the user clients (REST AP
 
 Finally, it should be possible to run the deployment through a Docker container. Make sure to have the [Kubeconfig file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) of your cluster and set the path in the following command accordingly:
 
-````@eval
-using Docs
-
-base_image = releaseVector()["docker-images"]["metal-stack"]["generic"]["deployment-base"]["tag"]
-
-t = raw"""
 ```bash
 export KUBECONFIG=<path-to-your-cluster-kubeconfig>
+export METAL_VERSION=<metal-stack-release-version>
 docker run --rm -it \
   -v $(pwd):/workdir \
   --workdir /workdir \
   -e KUBECONFIG="${KUBECONFIG}" \
   -e K8S_AUTH_KUBECONFIG="${KUBECONFIG}" \
   -e ANSIBLE_INVENTORY=inventories/control-plane.yaml \
-  ghcr.io/metal-stack/metal-deployment-base:%s \
+  ghcr.io/metal-stack/metal-deployment-base:${METAL_VERSION} \
   /bin/bash -ce \
     "ansible-playbook obtain_role_requirements.yaml
      ansible-galaxy install -r requirements.yaml
      ansible-playbook deploy_metal_control_plane.yaml"
 ```
-"""
-
-markdownTemplate(t, base_image)
-````
 
 :::tip
 If you are having issues regarding the deployment take a look at the [troubleshoot document](./06-troubleshoot.md). Please give feedback such that we can make the deployment of the metal-stack easier for you and for others!


### PR DESCRIPTION
Closes #83 

Julia was used to dynamically add the current release version to the .md document. I found no out-of-the box feature in docusaurus, so I replaced it with a simple text placeholder.

I also discovered that syntax highlighting wasn't working for bash-scripts and fixed that as well in the docs and blog pages. Some Reference-pages are not working well, because there is only a ```bash .. ``` highlighter supported. This has to be fixed in the component repositories.