### PR TITLE
Correct grammar of on-premises

### DIFF
--- a/docs/contributing/01-Proposals/MEP1/README.md
+++ b/docs/contributing/01-Proposals/MEP1/README.md
@@ -10,7 +10,7 @@ This enhancement proposal was replaced by [MEP18](../MEP18/README.md).
 
 ## Problem Statement
 
-We face the situation that we argue for running bare metal on premise because this way the customers can control where and how their software and data are processed and stored.
+We face the situation that we argue for running bare metal on-premises because this way the customers can control where and how their software and data are processed and stored.
 On the other hand, we have currently decided that our metal-api control plane components run on a kubernetes cluster (in our case on a cluster provided by one of the available hyperscalers).
 
 Running the control plane on Kubernetes has the following benefits:

--- a/docs/docs/02-General/02-why metal stack.md
+++ b/docs/docs/02-General/02-why metal stack.md
@@ -12,7 +12,7 @@ We hope that the following properties appeal to you as well.
 
 ## On-Premise
 
-Running on-premise gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premise is an easier connectivity to existing company networks.
+Running on-premises gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premises is an easier connectivity to existing company networks.
 
 ## Fast Provisioning
 

--- a/src/components/sections/Features.tsx
+++ b/src/components/sections/Features.tsx
@@ -59,7 +59,7 @@ export default function Features() {
                     Together with our friends from the open-source project
                     Gardener, metal-stack can serve as a cloud provider for
                     delivering bare-metal Kubernetes clusters at scale. We
-                    strive for being a serious, on-premise solution to
+                    strive for being a serious, on-premises solution to
                     hyperscaler offerings.
                   </p>
                 </div>

--- a/src/components/sections/Header.tsx
+++ b/src/components/sections/Header.tsx
@@ -81,7 +81,7 @@ export default function Header() {
                   metal-stack® is a set of microservices implementing Metal as a
                   Service (MaaS), turning a bunch of hardware into elastic cloud
                   infrastructure. It is built to manage the lifecycles for
-                  hundreds and thousands of servers inside your on-premise data
+                  hundreds and thousands of servers inside your on-premises data
                   center.
                 </p>
               </div>

--- a/versioned_docs/version-v0.21.10/contributing/01-Proposals/MEP1/README.md
+++ b/versioned_docs/version-v0.21.10/contributing/01-Proposals/MEP1/README.md
@@ -10,7 +10,7 @@ This enhancement proposal was replaced by [MEP18](../MEP18/README.md).
 
 ## Problem Statement
 
-We face the situation that we argue for running bare metal on premise because this way the customers can control where and how their software and data are processed and stored.
+We face the situation that we argue for running bare metal on-premises because this way the customers can control where and how their software and data are processed and stored.
 On the other hand, we have currently decided that our metal-api control plane components run on a kubernetes cluster (in our case on a cluster provided by one of the available hyperscalers).
 
 Running the control plane on Kubernetes has the following benefits:

--- a/versioned_docs/version-v0.21.10/docs/02-General/02-why metal stack.md
+++ b/versioned_docs/version-v0.21.10/docs/02-General/02-why metal stack.md
@@ -12,7 +12,7 @@ We hope that the following properties appeal to you as well.
 
 ## On-Premise
 
-Running on-premise gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premise is an easier connectivity to existing company networks.
+Running on-premises gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premises is an easier connectivity to existing company networks.
 
 ## Fast Provisioning
 

--- a/versioned_docs/version-v0.21.11/contributing/01-Proposals/MEP1/README.md
+++ b/versioned_docs/version-v0.21.11/contributing/01-Proposals/MEP1/README.md
@@ -10,7 +10,7 @@ This enhancement proposal was replaced by [MEP18](../MEP18/README.md).
 
 ## Problem Statement
 
-We face the situation that we argue for running bare metal on premise because this way the customers can control where and how their software and data are processed and stored.
+We face the situation that we argue for running bare metal on-premises because this way the customers can control where and how their software and data are processed and stored.
 On the other hand, we have currently decided that our metal-api control plane components run on a kubernetes cluster (in our case on a cluster provided by one of the available hyperscalers).
 
 Running the control plane on Kubernetes has the following benefits:

--- a/versioned_docs/version-v0.21.11/docs/02-General/02-why metal stack.md
+++ b/versioned_docs/version-v0.21.11/docs/02-General/02-why metal stack.md
@@ -12,7 +12,7 @@ We hope that the following properties appeal to you as well.
 
 ## On-Premise
 
-Running on-premise gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premise is an easier connectivity to existing company networks.
+Running on-premises gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premises is an easier connectivity to existing company networks.
 
 ## Fast Provisioning
 

--- a/versioned_docs/version-v0.21.8/contributing/01-Proposals/MEP1/README.md
+++ b/versioned_docs/version-v0.21.8/contributing/01-Proposals/MEP1/README.md
@@ -10,7 +10,7 @@ This enhancement proposal was replaced by [MEP18](../MEP18/README.md).
 
 ## Problem Statement
 
-We face the situation that we argue for running bare metal on premise because this way the customers can control where and how their software and data are processed and stored.
+We face the situation that we argue for running bare metal on-premises because this way the customers can control where and how their software and data are processed and stored.
 On the other hand, we have currently decided that our metal-api control plane components run on a kubernetes cluster (in our case on a cluster provided by one of the available hyperscalers).
 
 Running the control plane on Kubernetes has the following benefits:

--- a/versioned_docs/version-v0.21.8/docs/02-General/02-why metal stack.md
+++ b/versioned_docs/version-v0.21.8/docs/02-General/02-why metal stack.md
@@ -12,7 +12,7 @@ We hope that the following properties appeal to you as well.
 
 ## On-Premise
 
-Running on-premise gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premise is an easier connectivity to existing company networks.
+Running on-premises gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premises is an easier connectivity to existing company networks.
 
 ## Fast Provisioning
 

--- a/versioned_docs/version-v0.21.9/contributing/01-Proposals/MEP1/README.md
+++ b/versioned_docs/version-v0.21.9/contributing/01-Proposals/MEP1/README.md
@@ -10,7 +10,7 @@ This enhancement proposal was replaced by [MEP18](../MEP18/README.md).
 
 ## Problem Statement
 
-We face the situation that we argue for running bare metal on premise because this way the customers can control where and how their software and data are processed and stored.
+We face the situation that we argue for running bare metal on-premises because this way the customers can control where and how their software and data are processed and stored.
 On the other hand, we have currently decided that our metal-api control plane components run on a kubernetes cluster (in our case on a cluster provided by one of the available hyperscalers).
 
 Running the control plane on Kubernetes has the following benefits:

--- a/versioned_docs/version-v0.21.9/docs/02-General/02-why metal stack.md
+++ b/versioned_docs/version-v0.21.9/docs/02-General/02-why metal stack.md
@@ -12,7 +12,7 @@ We hope that the following properties appeal to you as well.
 
 ## On-Premise
 
-Running on-premise gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premise is an easier connectivity to existing company networks.
+Running on-premises gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premises is an easier connectivity to existing company networks.
 
 ## Fast Provisioning
 

--- a/versioned_docs/version-v0.22.0/contributing/01-Proposals/MEP1/README.md
+++ b/versioned_docs/version-v0.22.0/contributing/01-Proposals/MEP1/README.md
@@ -10,7 +10,7 @@ This enhancement proposal was replaced by [MEP18](../MEP18/README.md).
 
 ## Problem Statement
 
-We face the situation that we argue for running bare metal on premise because this way the customers can control where and how their software and data are processed and stored.
+We face the situation that we argue for running bare metal on-premises because this way the customers can control where and how their software and data are processed and stored.
 On the other hand, we have currently decided that our metal-api control plane components run on a kubernetes cluster (in our case on a cluster provided by one of the available hyperscalers).
 
 Running the control plane on Kubernetes has the following benefits:

--- a/versioned_docs/version-v0.22.0/docs/02-General/02-why metal stack.md
+++ b/versioned_docs/version-v0.22.0/docs/02-General/02-why metal stack.md
@@ -12,7 +12,7 @@ We hope that the following properties appeal to you as well.
 
 ## On-Premise
 
-Running on-premise gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premise is an easier connectivity to existing company networks.
+Running on-premises gives you data sovereignty and usually a better price / performance ratio than with hyperscalers — especially the larger you grow your environment. Another benefit of running on-premises is an easier connectivity to existing company networks.
 
 ## Fast Provisioning
 


### PR DESCRIPTION
## Description

Just being the grammar police. On-premise is incorrect, as "premise" is "an idea or theory". Correct usage is "premises".

One very verbose explanation can be found here:

https://cyberedgegroup.com/the-cybersecurity-industrys-most-frequent-typo-on-premise-vs-on-premises/

