### PR TITLE
fix(metal-api): api docs unavailable

### DIFF
--- a/src/components/Api.tsx
+++ b/src/components/Api.tsx
@@ -65,7 +65,7 @@ async function getReleaseVectorYaml(version: string) {
       releaseVectorPath += `tags/${getLatestRelease()}/release.yaml`;
       break;
     default:
-      releaseVectorPath += `tags/${version}/release.yaml`;
+      releaseVectorPath += `tags/${normalizedVersion(version)}/release.yaml`;
   }
 
   const response = await fetch(releaseVectorPath);
@@ -76,7 +76,17 @@ async function getReleaseVectorYaml(version: string) {
 function getLatestRelease(): string {
   let latest = "0.0.0";
   for (let version of versions) {
-    if (semver.gt(version, latest)) latest = version;
+    const v = normalizedVersion(version);
+    if (semver.gt(v, latest)) latest = v;
   }
-  return latest;
+  return normalizedVersion(latest);
+}
+
+function normalizedVersion(version: string): string {
+    const match = version.match(/^v?\d+\.\d+$/g);
+    if (match != null) {
+      return version + ".0";
+    }
+
+    return version;
 }


### PR DESCRIPTION
## Description

Due to the change to #214 we broke the API docs as we just used `v0.22` instead of `v0.22.0` leading to an invalid version.

In this fix I just added the missing `.0` when missing. If we change endpoints in a metal-stack patch release, these changes would not be reflected.

Should we consider this fine or treat it as a hotfix and try to figure out the correct patch level?

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
