### PR TITLE
Removed EOL switch from supported hardware list

### DIFF
--- a/docs/04-For Operators/01-hardware.md
+++ b/docs/04-For Operators/01-hardware.md
@@ -62,9 +62,7 @@ The following switch types are officially supported and verified by the metal-st
 |:----------|:--------------|:------------|:---------------|:-------|
 | Edge-Core | AS4600 Series | AS4625-54T  | Edgecore SONiC | stable |
 | Edge-Core | AS4600 Series | AS4630-54TE | Edgecore SONiC | stable |
-| Edge-Core | AS7700 Series | AS7712-32X  | Cumulus 3.7.13 | stable |
 | Edge-Core | AS7700 Series | AS7726-32X  | Cumulus 3.7.13 | stable |
-| Edge-Core | AS7700 Series | AS7712-32X  | Edgecore SONiC | stable |
 | Edge-Core | AS7700 Series | AS7726-32X  | Edgecore SONiC | stable |
 
 Other switch series and models might work but were not reported to us.


### PR DESCRIPTION
The AS7712-32X-EC is EOL. While units are still available, they are being phased out.

https://www.edge-core.com/product/as7712-32x-ec/
https://stordis.com/product/edgecore-networks-dcs501-as7712-32x-100g-cloud-data-center-switch/